### PR TITLE
`facto` -> `piga` in installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Example use cases:
 - Unpack the archive
 - Open `conf/application.conf` in the unpacked folder:
   - Configure a database. The easiest way is to set up a MariaDB server locally,
-    create an empty database called `facto` and configure it as follows:
+    create an empty database called `piga` and configure it as follows:
 
 ```
 db.default.driver=com.mysql.jdbc.Driver


### PR DESCRIPTION
I was a bit confused at first why I was being told to create a database called `facto` until I realized the docs were probably copied from your other project named facto :laughing:

I just quickly made an edit in the README on the web, let me know if I should update docs in other places.